### PR TITLE
feat: add async parsing with CLEF support and Seq integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,5 +40,6 @@ APP_PACKAGE := github.com/mikefero/sesh/internal/cmd
 include $(APP_DIR)/mk/build.mk
 include $(APP_DIR)/mk/common.mk
 include $(APP_DIR)/mk/dev.mk
+include $(APP_DIR)/mk/docker.mk
 include $(APP_DIR)/mk/test.mk
 include $(APP_DIR)/mk/tools.mk

--- a/internal/cmd/seq.go
+++ b/internal/cmd/seq.go
@@ -1,0 +1,203 @@
+/*
+Copyright © 2025 Michael Fero
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package cmd contains the command line package.
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/mikefero/sesh"
+	"github.com/spf13/cobra"
+)
+
+var (
+	seqURL          string
+	seqFlushTimeout time.Duration
+	seqBatchSize    int
+
+	entryQueue []sesh.LogEntry
+	queueMutex sync.Mutex
+)
+
+var seqCmd = &cobra.Command{
+	Use:   "seq [file]",
+	Short: "Parse Kong Gateway logs and send to Seq",
+	Long:  `Parse Kong Gateway logs and send them to Seq in CLEF format.`,
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Set up signal handling
+		sigChan := make(chan os.Signal, 1)
+		signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+		go func() {
+			<-sigChan
+			cancel()
+		}()
+
+		var reader *os.File
+		var err error
+
+		// Determine input source
+		if len(args) == 0 || (len(args) == 1 && args[0] == "--") {
+			// Read from stdin
+			reader = os.Stdin
+		} else {
+			// Read from file
+			reader, err = os.Open(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to open file %s: %w", args[0], err)
+			}
+			defer func() {
+				if err := reader.Close(); err != nil {
+					fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
+				}
+			}()
+		}
+
+		// Create the parser
+		parseJSONOutput = true // This is used for the shared function in parse CLI command
+		parser := sesh.NewParser()
+		parser = parser.WithCLEF(true)
+		parser = parser.WithFlushTimeout(seqFlushTimeout)
+		parser = parser.WithEntryCallback(func(entry sesh.LogEntry) {
+			addToQueue(entry)
+		})
+
+		// Create HTTP client for Seq
+		httpClient := &http.Client{
+			Timeout: 10 * time.Second,
+		}
+
+		// Start goroutine to process queue
+		go func() {
+			ticker := time.NewTicker(100 * time.Millisecond)
+			defer ticker.Stop()
+
+			for {
+				select {
+				case <-ctx.Done():
+					// Process remaining entries before exit
+					processQueue(httpClient)
+					return
+				case <-ticker.C:
+					processQueue(httpClient)
+				}
+			}
+		}()
+
+		// Parse the input source
+		result, err := parser.ParseReader(ctx, reader)
+
+		// Check if context was canceled
+		if ctx.Err() != nil {
+			fmt.Fprintf(os.Stderr, "Parsing interrupted\n")
+		} else if err != nil {
+			return fmt.Errorf("failed to parse logs: %w", err)
+		}
+
+		// Process any remaining entries in the queue before exiting
+		processQueue(httpClient)
+
+		// Output results
+		if err := outputResults(result); err != nil {
+			fmt.Fprintf(os.Stderr, "Error outputting results: %v\n", err)
+		}
+
+		return nil
+	},
+}
+
+// addToQueue adds an entry to the processing queue.
+func addToQueue(entry sesh.LogEntry) {
+	queueMutex.Lock()
+	defer queueMutex.Unlock()
+	entryQueue = append(entryQueue, entry)
+}
+
+// processQueue sends all queued entries to Seq in batches.
+func processQueue(client *http.Client) {
+	queueMutex.Lock()
+	entries := make([]sesh.LogEntry, len(entryQueue))
+	copy(entries, entryQueue)
+	entryQueue = entryQueue[:0] // Clear the queue
+	queueMutex.Unlock()
+
+	for i := 0; i < len(entries); i += seqBatchSize {
+		end := min(i+seqBatchSize, len(entries))
+		batch := entries[i:end]
+
+		if err := sendBatchToSeq(client, batch); err != nil {
+			fmt.Fprintf(os.Stderr, "Error sending batch to Seq: %v\n", err)
+		}
+	}
+}
+
+// sendBatchToSeq sends multiple log entries to Seq in CLEF format as a batch.
+func sendBatchToSeq(client *http.Client, entries []sesh.LogEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	var batchData bytes.Buffer
+	for _, entry := range entries {
+		clefData, err := jsonEntry(entry)
+		if err != nil {
+			return fmt.Errorf("failed to marshal entry: %w", err)
+		}
+		batchData.Write(clefData)
+		batchData.WriteString("\n") // CLEF format requires newline separation
+	}
+
+	// Send HTTP POST to Seq
+	resp, err := client.Post(seqURL, "application/vnd.serilog.clef", &batchData)
+	if err != nil {
+		return fmt.Errorf("failed to post batch to Seq: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error closing response body: %v\n", err)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("invalid status code returned from Seq: %v", resp)
+	}
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(seqCmd)
+
+	// Add flags
+	seqCmd.Flags().DurationVar(&seqFlushTimeout, "flush-timeout", sesh.DefaultFlushTimeout,
+		"Timeout to flush incomplete multi-line entries when streaming")
+	seqCmd.Flags().StringVar(&seqURL, "url", "http://localhost:5480/ingest/clef",
+		"Seq ingestion URL")
+	seqCmd.Flags().IntVar(&seqBatchSize, "batch-size", 1000,
+		"Number of log entries to batch together when sending to Seq")
+}

--- a/internal/docker/docker-compose.yml
+++ b/internal/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  seq:
+    image: datalust/seq:latest
+    container_name: seq
+    ports:
+      - "5480:80"
+    environment:
+      - ACCEPT_EULA=Y
+      - SEQ_FIRSTRUN_NOAUTHENTICATION=true
+    networks:
+      - seq
+
+networks:
+  seq:
+    driver: bridge

--- a/mk/docker.mk
+++ b/mk/docker.mk
@@ -1,0 +1,35 @@
+# --------------------------------------------------
+# Docker tooling
+# --------------------------------------------------
+
+# Determine docker compose command
+ifeq (, $(shell which docker compose 2> /dev/null))
+  ifeq (, $(shell which docker-compose 2> /dev/null))
+    $(error "Neither 'docker compose' nor 'docker-compose' found in PATH. Please install Docker Compose.")
+  else
+    DOCKER_COMPOSE = docker-compose
+  endif
+else
+  DOCKER_COMPOSE = docker compose
+endif
+
+# Check for cURL
+ifeq (, $(shell which curl 2> /dev/null))
+  $(error "cURL not found in PATH. Please install cURL.")
+endif
+
+DOCKER_COMPOSE_FILE = $(APP_DIR)/internal/docker/docker-compose.yml
+
+.PHONY: seq-start
+seq-start: ## Start Seq logging server and wait for it to be ready
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) up -d seq
+	@echo "Waiting for Seq to be ready..."
+	@until curl -s -f -X POST http://localhost:5480/ingest/clef >/dev/null 2>&1; do \
+		echo "Seq not ready, waiting..."; \
+		sleep 1; \
+	done
+	@echo "Seq is ready!"
+
+.PHONY: seq-stop
+seq-stop: ## Stop Seq logging server
+	@$(DOCKER_COMPOSE) -f $(DOCKER_COMPOSE_FILE) down seq


### PR DESCRIPTION
- Add async callback processing using goroutines to prevent parser blocking on slow operations like network requests
- Implement CLEF (Compact Log Event Format) support with automatic field mapping (@t, @m, @l, @i) and Serilog level conversion
- Add new seq command for sending parsed logs to Seq with batching support (configurable batch size, default 1000 entries)
- Add ordered queue system in seq command to maintain log entry sequence while allowing async processing
- Update Makefile with seq-start/seq-stop targets including health checks to wait for Seq endpoint availability
- Update README with CLEF examples and Docker operations section

The async parsing prevents blocking when callbacks perform slow operations like HTTP requests, while the queue system in seq command ensures log entries are processed in correct order for accurate analysis in centralized logging systems.