### PR TITLE
feat: add Seq OTLP exporter to otel-collector

### DIFF
--- a/internal/docker/config/otel-collector-config.yml
+++ b/internal/docker/config/otel-collector-config.yml
@@ -18,6 +18,13 @@ exporters:
     sampling_initial: 5
     sampling_thereafter: 200
 
+  # Seq exporter - forwards logs to Seq UI via OTLP
+  otlphttp/seq:
+    endpoint: http://seq:80
+    logs_endpoint: http://seq:80/ingest/otlp/v1/logs
+    tls:
+      insecure: true
+
 extensions:
   health_check:
     endpoint: 0.0.0.0:13133
@@ -28,4 +35,4 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug]
+      exporters: [debug, otlphttp/seq]

--- a/internal/docker/docker-compose.yml
+++ b/internal/docker/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - SEQ_FIRSTRUN_NOAUTHENTICATION=true
     networks:
       - seq
+      - shared
+    restart: unless-stopped
 
   otel-collector:
     image: otel/opentelemetry-collector:latest
@@ -22,10 +24,13 @@ services:
       - "13133:13133" # Health check extension
     networks:
       - otel
+      - shared
     restart: unless-stopped
 
 networks:
   seq:
     driver: bridge
   otel:
+    driver: bridge
+  shared:
     driver: bridge


### PR DESCRIPTION
Configure otel-collector to forward logs to Seq via OTLP HTTP protocol. Logs are now fanned out to both debug exporter (for inspection) and Seq UI (for visualization and analysis).

- Add shared network to docker-compose for seq and otel-collector communication
- Add otlphttp/seq exporter to otel-collector config
- Configure pipeline to export to [debug, otlphttp/seq]
- Use HTTP protocol (Seq requires TLS for gRPC)

This enables a complete observability workflow:
1. sesh otel sends logs to otel-collector via OTLP
2. otel-collector forwards to Seq's OTLP endpoint
3. Logs viewable in Seq UI at http://localhost:5480